### PR TITLE
Fix vertical padding in weekly view

### DIFF
--- a/app/screens/prayer-times/src/main/java/org/ibadalrahman/prayertimes/view/WeeklyPrayerTimesView.kt
+++ b/app/screens/prayer-times/src/main/java/org/ibadalrahman/prayertimes/view/WeeklyPrayerTimesView.kt
@@ -49,14 +49,11 @@ fun WeeklyPrayerTimesView(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.tertiaryContainer)
-            .padding(
-                top = 30.dp,
-                bottom = 0.dp,
-                start = 20.dp,
-                end = 20.dp
-            )
+            .padding(horizontal = 20.dp)
             .verticalScroll(ScrollState(0))
     ) {
+        Spacer(modifier = Modifier.height(30.dp))
+
         Text(
             text = stringResource(id = R.string.timings).uppercase(),
             style = MaterialTheme.typography.bodyMedium.copy(
@@ -161,6 +158,8 @@ fun WeeklyPrayerTimesView(
                 }
             }
         }
+
+        Spacer(modifier = Modifier.height(30.dp))
     }
 }
 


### PR DESCRIPTION
Vertical padding in `weekly` view is inconsistent with `daily` view

In `weekly`:
1. bottom padding is 0
2. top padding is parent of parent column modifier, which causes a cut look when scrolling