### PR TITLE
Set room db query return type to optionals

### DIFF
--- a/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/PrayerTimesRepositoryImpl.kt
+++ b/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/PrayerTimesRepositoryImpl.kt
@@ -31,7 +31,8 @@ class PrayerTimesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getWeekPrayerTimes(weekId: Int): Result<WeekPrayerTimes> {
-        val weekPrayerTimes = localDatasource.findWeekPrayerTimeById(id = weekId).toDomain()
+        val weekPrayerTimes = localDatasource.findWeekPrayerTimeById(id = weekId)?.toDomain()
+            ?: return Result.failure(IllegalArgumentException("No data found for the given weekId"))
         return Result.success(weekPrayerTimes)
     }
 

--- a/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesDao.kt
+++ b/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesDao.kt
@@ -17,11 +17,11 @@ interface PrayerTimesDao {
     fun insertWeekPrayerTime(vararg week: WeekEntity)
 
     @Query("SELECT * FROM day_prayer_times WHERE id = (:id)")
-    fun findDayPrayerTimeById(id: Int): DayPrayerTimesEntity
+    fun findDayPrayerTimeById(id: Int): DayPrayerTimesEntity?
 
     @Transaction
     @Query("SELECT * FROM week_prayer_times WHERE id = (:id)")
-    fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity
+    fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity?
 
     @Query("DELETE FROM day_prayer_times")
     fun deleteAllDayPrayerTimes()

--- a/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesLocalDataSource.kt
+++ b/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesLocalDataSource.kt
@@ -8,7 +8,7 @@ interface PrayerTimesLocalDataSource {
     fun insertDayPrayerTime(vararg prayerTimes: DayPrayerTimesEntity)
     fun insertWeekPrayerTime(vararg week: WeekEntity)
     fun findDayPrayerTimeById(id: Int): DayPrayerTimesEntity?
-    fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity
+    fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity?
     fun getDigest(year: Int): String
     fun setDigest(year: Int, digest: String)
     fun deleteAllDigests()

--- a/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesLocalDataSourceImpl.kt
+++ b/app/data/prayer-times-repository/src/main/java/org/ibadalrahman/prayertimes/repository/data/local/PrayerTimesLocalDataSourceImpl.kt
@@ -24,7 +24,7 @@ class PrayerTimesLocalDataSourceImpl @Inject constructor(
     override fun findDayPrayerTimeById(id: Int): DayPrayerTimesEntity? =
         prayerTimesDao.findDayPrayerTimeById(id)
 
-    override fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity =
+    override fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity? =
         prayerTimesDao.findWeekPrayerTimeById(id)
 
     override fun getDigest(year: Int): String = sharedPreferences.getDigest(year = year)


### PR DESCRIPTION
```kotlin
    @Transaction
    @Query("SELECT * FROM week_prayer_times WHERE id = (:id)")
    fun findWeekPrayerTimeById(id: Int): WeekPrayerTimesEntity
```
if `id` does not exist in the database this would crash. room would try to return null but the return type of the function is non-nullable

same for `findDayPrayerTimeById` function